### PR TITLE
fix(provider): rename `api_token` attribute to `api_key`

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -15,7 +15,7 @@ description: |-
 ```terraform
 provider "statuscake" {
   # you can also provide the api key via the STATUSCAKE_API_KEY env variable
-  api_token = "..."
+  api_key = "..."
 }
 ```
 
@@ -24,4 +24,4 @@ provider "statuscake" {
 
 ### Optional
 
-- **api_token** (String, Sensitive)
+- **api_key** (String, Sensitive)

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -1,4 +1,4 @@
 provider "statuscake" {
   # you can also provide the api key via the STATUSCAKE_API_KEY env variable
-  api_token = "..."
+  api_key = "..."
 }

--- a/statuscake/provider.go
+++ b/statuscake/provider.go
@@ -11,7 +11,7 @@ func New(version string) func() *schema.Provider {
 	return func() *schema.Provider {
 		p := &schema.Provider{
 			Schema: map[string]*schema.Schema{
-				"api_token": {
+				"api_key": {
 					Type:        schema.TypeString,
 					Optional:    true,
 					Sensitive:   true,
@@ -33,15 +33,15 @@ func New(version string) func() *schema.Provider {
 
 func configure(version string, p *schema.Provider) func(context.Context, *schema.ResourceData) (interface{}, diag.Diagnostics) {
 	return func(ctx context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
-		apiToken := d.Get("api_token").(string)
+		apiKey := d.Get("api_key").(string)
 
 		var diags diag.Diagnostics
 
-		if apiToken == "" {
-			return nil, diag.Errorf("Missing api_token")
+		if apiKey == "" {
+			return nil, diag.Errorf("Missing api_key")
 		}
 
-		client := statuscake.NewAPIClient(apiToken)
+		client := statuscake.NewAPIClient(apiKey)
 
 		return client, diags
 	}

--- a/statuscake/provider_test.go
+++ b/statuscake/provider_test.go
@@ -27,9 +27,9 @@ func testAccPreCheck(t *testing.T) {
 }
 
 func statusCakeAPIClient() *statuscake.APIClient {
-	apiToken := os.Getenv("STATUSCAKE_API_KEY")
+	apiKey := os.Getenv("STATUSCAKE_API_KEY")
 
-	return statuscake.NewAPIClient(apiToken)
+	return statuscake.NewAPIClient(apiKey)
 }
 
 func TestProvider(t *testing.T) {


### PR DESCRIPTION
Everywhere I can find within StatusCake refers to this as an api _key_,
with the `statuscake-go` client being the exception.

We should be consistent, and go with what it's referred to in the admin
ui and by our own environment variable to make things less surprising.