### PR TITLE
ci: use exact version of `hashicorp/ghaction-import-gpg` action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,7 +123,7 @@ jobs:
 
       - name: Import GPG key
         id: import_gpg
-        uses: hashicorp/ghaction-import-gpg@v2
+        uses: hashicorp/ghaction-import-gpg@v2.1.0
         env:
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           PASSPHRASE: ${{ secrets.PASSPHRASE }}


### PR DESCRIPTION
I thought actions did magic semver stuff to figure out the major, but
apparently its based on a more static existence of an actual v<major>
tag for the action (which this action doesn't have)?

tbh this actually rings a bell - I suspect I've hit this issue before with another action and just forgot about it 🤷 