### PR TITLE
ci: actually do run checks against `main` branch too

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -2,6 +2,9 @@ name: Checks
 
 on:
   pull_request:
+  push:
+    branches:
+      - main
 
 env:
   STATUSCAKE_API_KEY: 'nothing'


### PR DESCRIPTION
The `release` workflow actually only runs on tag events, so it would be
good to run the `checks` workflow against `main`